### PR TITLE
Add Flutter.xcframework binaries

### DIFF
--- a/codesign.py
+++ b/codesign.py
@@ -124,6 +124,18 @@ ARCHIVES = [
                     'Flutter',
                     ],
                 },
+            {
+                'path': 'Flutter.xcframework/ios-x86_64-simulator/Flutter.framework',
+                'files': [
+                    'Flutter',
+                    ]
+                },
+            {
+                'path': 'Flutter.xcframework/ios-armv7_arm64/Flutter.framework',
+                'files': [
+                    'Flutter',
+                    ]
+                },
             ],
         'files_with_entitlements': [
             'gen_snapshot_arm64',
@@ -143,6 +155,18 @@ ARCHIVES = [
                     'Flutter',
                     ]
                 },
+            {
+                'path': 'Flutter.xcframework/ios-x86_64-simulator/Flutter.framework',
+                'files': [
+                    'Flutter',
+                    ]
+                },
+            {
+                'path': 'Flutter.xcframework/ios-armv7_arm64/Flutter.framework',
+                'files': [
+                    'Flutter',
+                    ]
+                },
             ],
         },
     {
@@ -154,6 +178,18 @@ ARCHIVES = [
         'files': [
             {
                 'path': 'Flutter.framework.zip',
+                'files': [
+                    'Flutter',
+                    ]
+                },
+            {
+                'path': 'Flutter.xcframework/ios-x86_64-simulator/Flutter.framework',
+                'files': [
+                    'Flutter',
+                    ]
+                },
+            {
+                'path': 'Flutter.xcframework/ios-armv7_arm64/Flutter.framework',
                 'files': [
                     'Flutter',
                     ]


### PR DESCRIPTION
Add Flutter.xcframework binaries to codesigning script.

### Related Issues
Part of https://github.com/flutter/flutter/pull/60118 via https://github.com/flutter/flutter/pull/60109

https://github.com/flutter/engine/pull/22506
https://github.com/flutter/engine/pull/22664
https://flutter-review.googlesource.com/c/recipes/+/9020