### PR TITLE
[codesign] sign macOS arm64 artifacts for 3.7 releases

### DIFF
--- a/codesign.py
+++ b/codesign.py
@@ -63,11 +63,22 @@ ARCHIVES = [
             ],
         },
     {
+        'path': 'darwin-arm64/artifacts.zip',
+        'files_with_entitlements': [
+            'flutter_tester',
+            'gen_snapshot',
+            'impellerc',
+            'libpath_ops.dylib',
+            'libtessellator.dylib',
+            ],
+        },
+    {
         'path': 'darwin-x64/artifacts.zip',
         'files_with_entitlements': [
             'flutter_tester',
             'gen_snapshot',
             'impellerc',
+            'libpath_ops.dylib',
             'libtessellator.dylib',
             ],
         },


### PR DESCRIPTION
temporary fix to https://github.com/flutter/flutter/issues/111764

edit existing release codesign script to also codesign darwin-arm64