### PR TITLE
add wasm-opt binary

### DIFF
--- a/codesign.py
+++ b/codesign.py
@@ -52,6 +52,7 @@ ARCHIVES = [
             'dart-sdk/bin/dart',
             'dart-sdk/bin/dartaotruntime',
             'dart-sdk/bin/utils/gen_snapshot',
+            'dart-sdk/bin/utils/wasm-opt',
             ],
         },
     {
@@ -60,6 +61,7 @@ ARCHIVES = [
             'dart-sdk/bin/dart',
             'dart-sdk/bin/dartaotruntime',
             'dart-sdk/bin/utils/gen_snapshot',
+            'dart-sdk/bin/utils/wasm-opt',
             ],
         },
     {


### PR DESCRIPTION
For manual script, since the binary is currently added to tip of master, it won't show up until a future beta release. 

We will start to use this new script, when a future beta cuts after https://github.com/flutter/flutter/pull/122806 .
Might need to maintain a separate script for stable releases.
